### PR TITLE
"remove" option for use with gulp-postcss so we can remove :root on per-file-basis

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,38 @@ npm install --save postcss-remove-root
 
 See the [PostCSS documentation](https://github.com/postcss/postcss#usage) for examples on how to use this plugin in different environments.
 
+## Options
+
+### `remove`
+
+Type: `boolean`
+Default: `true`
+
+Allows the plugin to be turned on or off. 
+
+This is useful when combined with [gulp-postcss](https://github.com/postcss/gulp-postcss)
+with a custom callback passing in a vinyl file object. 
+
+An example allowing the plugin to be used on a per-file-basis: 
+
+```js
+var gulp = require('gulp');
+var postcss = require('gulp-postcss');
+
+gulp.task('css', function () {
+    function callback(file) {
+        return {
+            plugins: [
+                require('postcss-remove-root')({ remove: file.basename !== 'base.css' })
+            ]
+        }
+    }
+    return gulp.src('./src/*.css')
+        .pipe(postcss(callback))
+        .pipe(gulp.dest('./dest'));
+});
+```
+
 ## Contributing
 
 - ⇄ Pull requests and ★ Stars are always welcome.

--- a/index.js
+++ b/index.js
@@ -6,13 +6,16 @@
  */
 
 var postcss = require('postcss');
+var assign = require('object-assign');
 
 module.exports = postcss.plugin('remove-root', function (opts) {
   return function (css) {
-    opts = opts || {};
+    opts = assign({
+      remove: true
+    }, opts);
 
     css.walkRules(function (rule) {
-      if (rule.selector === ':root') {
+      if (rule.selector === ':root' && opts.remove !== false) {
         rule.remove();
       }
     });

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "homepage": "https://github.com/cbracco/postcss-remove-root",
   "dependencies": {
-    "postcss": "^5.0.13"
+    "postcss": "^5.0.13",
+    "object-assign": "^4.0.1"
   },
   "devDependencies": {
     "postcss-custom-properties": "^5.0.0",


### PR DESCRIPTION
This is a little left field... No pressure on actually including this into master or releasing it.

It all comes out of an [issue I started](https://github.com/postcss/postcss-import/issues/349) for postcss-import. Long story short - it's nice to be able to include `:root` custom property declarations in some files, and not others when storing vars in partials like in Sass.

This PR adds a `remove` option with some docs that explain how to use it. 

I'm running this with our build tools and it's working great. `:root` ends up in my base.css and all the other css files don't double up. 